### PR TITLE
Fixed issue in where label color did not change correctly.  

### DIFF
--- a/src/CodeOfSpec20BookFilm/ImdbFilmListPresenter.class.st
+++ b/src/CodeOfSpec20BookFilm/ImdbFilmListPresenter.class.st
@@ -117,7 +117,7 @@ ImdbFilmListPresenter >> initializePresenters [
 			            (SpStringTableColumn title: 'Year' evaluated: #year);
 		            yourself.
 	detail := self instantiate: ImdbFilmPresenter.
-	detail enabled: false.
+	detail editable: false.
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
There was a comment from Esteban on page 33 of the Application Building with Spec 2.0 that the code for this example didn't work:

””esteban”” I get a grey not read label. No idea why.

I confirmed it worked as he saw.  It turned out there was a typo in the between the book and the code in this repository. I changed the code to match the book and now it works as expected.